### PR TITLE
Fix uv setup usage

### DIFF
--- a/how-ai-works/README.md
+++ b/how-ai-works/README.md
@@ -24,7 +24,7 @@ open http://localhost:8000
 
 ```bash
 # Backend
-uv install && uv run ai-server
+uv sync && uv run ai-server
 
 # Frontend (separate terminal)
 cd frontend && npm install && npm run dev

--- a/how-ai-works/frontend/README.md
+++ b/how-ai-works/frontend/README.md
@@ -32,7 +32,7 @@ npm run build
 1. **Start the backend server first:**
    ```bash
    cd ../  # Navigate to how-ai-works directory
-   uv run ai-server
+   uv sync && uv run ai-server
    ```
 
 2. **Start the frontend (in a new terminal):**

--- a/how-ai-works/frontend/src/views/StreamingSimulation.vue
+++ b/how-ai-works/frontend/src/views/StreamingSimulation.vue
@@ -464,7 +464,7 @@ onMounted(() => {
         Please start the FastAPI server to use the AI streaming simulation.
       </p>
       <div class="bg-gray-100 p-2 rounded text-sm">
-        <code>cd how-ai-works && uv run ai-server</code>
+        <code>cd how-ai-works && uv sync && uv run ai-server</code>
       </div>
     </div>
 

--- a/how-ai-works/frontend/src/views/WordPrediction.vue
+++ b/how-ai-works/frontend/src/views/WordPrediction.vue
@@ -301,7 +301,7 @@ onMounted(() => {
         Please start the FastAPI server to use the AI predictions.
       </p>
       <div class="bg-gray-100 p-2 rounded text-sm">
-        <code>cd how-ai-works && uv run ai-server</code>
+        <code>cd how-ai-works && uv sync && uv run ai-server</code>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- replace `uv install` with `uv sync` in backend dev instructions
- mention `uv sync` in frontend README
- show `uv sync` in UI instructions when backend is not running

## Testing
- `uv pip check`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68439c7396648332be65f5f72b3abbc4